### PR TITLE
Replace rm -rf with platform independent command

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"scripts": {
-		"clean": "rm -rf ./dist",
+		"clean": "rimraf ./dist",
 		"build": "npm run clean && npx tsc -d && npx tsc-alias",
 		"postinstall": "npm run build"
 	},


### PR DESCRIPTION
This just replaces the rm -rf command with rimraf, which works on all platforms instead of just linux/unix systems. Tested on ubuntu and windows